### PR TITLE
Allow rotation of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ White balance values on the Raspberry Pi camera are set by adjusting the red and
 
 Note: These values will be updated over time as I find more time to calibrate my Pi camera against a few DSLRs and other devices which are much more accurate! Please file an issue if you can help make these mappings better, or find a nicer way to adjust calibrations rather than a `red_gain` and `blue_gain` value.
 
+### Rotation
+
+Depending on the placement of your camera, the picture taken could be upside down. To correct this, the
+camera offers a possibility to rotate the images by `90`, `180` or `270` degrees. Use `0` to not rotate
+the images.
+
 ## License
 
 MIT License.

--- a/example.config.yml
+++ b/example.config.yml
@@ -34,3 +34,6 @@ shutter_speed: 0
 white_balance: { }
   # red_gain: 1.3
   # blue_gain: 1.75
+
+# Rotate the images taken by the camera. Possible value are 0, 90, 180 or 270
+rotation: 0

--- a/timelapse.py
+++ b/timelapse.py
@@ -38,6 +38,10 @@ try:
         camera.awb_mode = 'off'
         camera.awb_gains = (config['white_balance']['red_gain'], config['white_balance']['blue_gain'])
 
+    # Set camera rotation
+    if config['rotation']:
+        camera.rotation = config['rotation']
+
     # Capture images in series.
     for i in range(config['total_images']):
         camera.capture(dir + '/image{0:05d}.jpg'.format(i))


### PR DESCRIPTION
This small change allows the rotation of the images. Depending on the placement of the camera, this might be necessary.