### PR TITLE
Show Animated GIF and Video MP4 commands to aid debugging

### DIFF
--- a/timelapse.py
+++ b/timelapse.py
@@ -94,12 +94,12 @@ capture_image()
 # TODO: These may not get called after the end of the threading process...
 # Create an animated gif (Requires ImageMagick).
 if config['create_gif']:
-    command = 'convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif' # noqa
+    command = 'convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif'  # noqa
     print '\nCreating animated gif: ' + command + '\n'
     os.system(command)
 
 # Create a video (Requires avconv - which is basically ffmpeg).
 if config['create_video']:
-    command = 'avconv -framerate 20 -i ' + dir + '/image%05d.jpg -vf format=yuv420p ' + dir + '/timelapse.mp4' # noqa
+    command = 'avconv -framerate 20 -i ' + dir + '/image%05d.jpg -vf format=yuv420p ' + dir + '/timelapse.mp4'  # noqa
     print '\nCreating video: ' + command + '\n'
     os.system(command)

--- a/timelapse.py
+++ b/timelapse.py
@@ -67,6 +67,7 @@ def capture_image():
         set_camera_options(camera)
 
         # Capture a picture.
+        print '\nCapture picture: ' + str(image_number) + '\n'
         camera.capture(dir + '/image{0:05d}.jpg'.format(image_number))
         camera.close()
 
@@ -93,10 +94,12 @@ capture_image()
 # TODO: These may not get called after the end of the threading process...
 # Create an animated gif (Requires ImageMagick).
 if config['create_gif']:
-    print '\nCreating animated gif.\n'
-    os.system('convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif')  # noqa
+    command = 'convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif'
+    print '\nCreating animated gif: ' + command + '\n'
+    os.system(command)  # noqa
 
 # Create a video (Requires avconv - which is basically ffmpeg).
 if config['create_video']:
-    print '\nCreating video.\n'
-    os.system('avconv -framerate 20 -i ' + dir + '/image%05d.jpg -vf format=yuv420p ' + dir + '/timelapse.mp4')  # noqa
+    command = 'avconv -framerate 20 -i ' + dir + '/image%05d.jpg -vf format=yuv420p ' + dir + '/timelapse.mp4'
+    print '\nCreating video: ' + command + '\n'
+    os.system(command)  # noqa

--- a/timelapse.py
+++ b/timelapse.py
@@ -94,12 +94,12 @@ capture_image()
 # TODO: These may not get called after the end of the threading process...
 # Create an animated gif (Requires ImageMagick).
 if config['create_gif']:
-    command = 'convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif'
+    command = 'convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif' # noqa
     print '\nCreating animated gif: ' + command + '\n'
-    os.system(command)  # noqa
+    os.system(command)
 
 # Create a video (Requires avconv - which is basically ffmpeg).
 if config['create_video']:
-    command = 'avconv -framerate 20 -i ' + dir + '/image%05d.jpg -vf format=yuv420p ' + dir + '/timelapse.mp4'
+    command = 'avconv -framerate 20 -i ' + dir + '/image%05d.jpg -vf format=yuv420p ' + dir + '/timelapse.mp4' # noqa
     print '\nCreating video: ' + command + '\n'
-    os.system(command)  # noqa
+    os.system(command)


### PR DESCRIPTION
Add message for each image capture to understand when image capture takes place and when Animated GIF and Video MP4 creation takes place. To clearly show users what is taking place display the actual commands issued for Animated GIF and Video MP4 creation. This is in preparation to debugging the "TODO These may not get called after the end of the capture_image process..."

Adding

    Capture picture: 0
    Capture picture: 1
    Capture picture: 2
    Capture picture: 3
    Capture picture: 4
    Capture picture: 5
    Capture picture: 6
    Capture picture: 7
    Capture picture: 8
    Capture picture: 9

For example, change from 

    Creating animated gif.
    Creating video.

to

    Creating animated gif: convert -delay 10 -loop 0 /home/pi/Desktop/pi-timelapse/series-2018-12-20_18-43-32/image*.jpg /home/pi/Desktop/pi-timelapse/series-2018-12-20_18-43-32-timelapse.gif
    Creating video: avconv -framerate 20 -i /home/pi/Desktop/pi-timelapse/series-2018-12-20_18-43-32/image%05d.jpg -vf format=yuv420p /home/pi/Desktop/pi-timelapse/series-2018-12-20_18-43-32/timelapse.mp4

