### PR TITLE
Fix location of timelapse.gif put it into series subdirectory

### DIFF
--- a/timelapse.py
+++ b/timelapse.py
@@ -94,7 +94,7 @@ capture_image()
 # Create an animated gif (Requires ImageMagick).
 if config['create_gif']:
     print '\nCreating animated gif.\n'
-    os.system('convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '-timelapse.gif')  # noqa
+    os.system('convert -delay 10 -loop 0 ' + dir + '/image*.jpg ' + dir + '/timelapse.gif')  # noqa
 
 # Create a video (Requires avconv - which is basically ffmpeg).
 if config['create_video']:


### PR DESCRIPTION
Such a little change (a '-' to a '/') to get the resulting animated gif to be located inside of the series subdirectory. For example, previously the file was /home/pi/Desktop/pi-timelapse/series-2018-12-20_18-43-32-timelapse.gif and afterwards it was /home/pi/Desktop/pi-timelapse/series-2018-12-20_18-43-32/timelapse.gif (see the subtle -timelapse.gif to /timelapse.gif). Now all files are housed in their series subdirectory: the captured images, the animated gif and the video mp4 file.